### PR TITLE
Fix/missing steps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ OSCAR_DASHBOARD_NAVIGATION.append(
 ```
 Furthermore you need to add the url-pattern to your `urls.py`
 ``` python
-(r'^dashboard/accounts/', include(accounts_app.urls)),
+urlpatterns = patterns('',
+    ...
+    (r'^dashboard/accounts/', include(accounts_app.urls)),
+)
 ```
 
 You should also set-up a cronjob that calls:


### PR DESCRIPTION
A couple of installation steps were missing in the `readme.rst` Those steps are necessary if you want to install the extension in Oscar.
