### PR TITLE
Use django-1.6 transaction methods

### DIFF
--- a/accounts/abstract_models.py
+++ b/accounts/abstract_models.py
@@ -268,7 +268,7 @@ class PostingManager(models.Manager):
         # Write out transfer (which involves multiple writes).  We use a
         # database transaction to ensure that all get written out correctly.
         self.verify_transfer(source, destination, amount, user)
-        with transaction.commit_on_success():
+        with transaction.atomic():
             transfer = self.get_query_set().create(
                 source=source,
                 destination=destination,


### PR DESCRIPTION
This isn't ready to merge as is because it breaks django-1.5. However it is a necessary change for django-1.6 if the facade is used inside another atomic block.