### PR TITLE
Include templates when installing via pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.md
 include LICENSE
-recursive-include accounts/templates/ *.html
+recursive-include accounts/templates *.html


### PR DESCRIPTION
Without this I get

warning: no files found matching '*.html' under directory 'accounts/templates/'

when doing setup.py egg_info and indeed the templates are not copied.
