### PR TITLE
make django-oscar-accounts really could work without oscar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import sys
 from setuptools import find_packages, setup
 
 install_requires=[
-    'django-oscar>=1.1.1',
     'python-dateutil>=2.4,<3.0',
 ]
 
@@ -53,6 +52,7 @@ setup(
     setup_requires=setup_requires,
     extras_require={
         'test': tests_require,
+        'oscar': ['django-oscar>=1.1.1', ],
     },
     use_scm_version=True,
 )

--- a/src/oscar_accounts/abstract_models.py
+++ b/src/oscar_accounts/abstract_models.py
@@ -8,10 +8,10 @@ from django.db.models import Sum
 from django.utils import six, timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
-from oscar.core.compat import AUTH_USER_MODEL
 from treebeard.mp_tree import MP_Node
 
 from oscar_accounts import exceptions
+from oscar_accounts.compact_oscar import AUTH_USER_MODEL
 
 
 class ActiveAccountManager(models.Manager):

--- a/src/oscar_accounts/api/app.py
+++ b/src/oscar_accounts/api/app.py
@@ -1,8 +1,8 @@
 from django.conf.urls import patterns, url
 from django.views.decorators.csrf import csrf_exempt
-from oscar.core.application import Application
 
 from oscar_accounts.api import decorators, views
+from oscar_accounts.compact_oscar import Application
 
 
 class APIApplication(Application):

--- a/src/oscar_accounts/api/views.py
+++ b/src/oscar_accounts/api/views.py
@@ -9,10 +9,10 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import generic
-from oscar.core.loading import get_model
 
 from oscar_accounts import codes, exceptions, facade, names
 from oscar_accounts.api import errors
+from oscar_accounts.compact_oscar import get_model
 
 Account = get_model('oscar_accounts', 'Account')
 AccountType = get_model('oscar_accounts', 'AccountType')

--- a/src/oscar_accounts/checkout/forms.py
+++ b/src/oscar_accounts/checkout/forms.py
@@ -2,8 +2,8 @@ from decimal import Decimal as D
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from oscar.core.loading import get_model
-from oscar.templatetags.currency_filters import currency
+
+from oscar_accounts.compact_oscar import get_model, currency
 
 Account = get_model('oscar_accounts', 'Account')
 

--- a/src/oscar_accounts/checkout/gateway.py
+++ b/src/oscar_accounts/checkout/gateway.py
@@ -1,8 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
-from oscar.apps.payment.exceptions import UnableToTakePayment
-from oscar.core.loading import get_model
 
 from oscar_accounts import codes, core, exceptions, facade
+from oscar_accounts.compact_oscar import get_model, UnableToTakePayment
 
 Account = get_model('oscar_accounts', 'Account')
 Transfer = get_model('oscar_accounts', 'Transfer')

--- a/src/oscar_accounts/codes.py
+++ b/src/oscar_accounts/codes.py
@@ -1,7 +1,7 @@
 import random
 import string
 
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 Account = get_model('oscar_accounts', 'Account')
 

--- a/src/oscar_accounts/compact_oscar.py
+++ b/src/oscar_accounts/compact_oscar.py
@@ -7,6 +7,7 @@ except ImportError:
     from django.apps.config import MODELS_MODULE_NAME
     from django.conf import settings
     from django.core.exceptions import ImproperlyConfigured, AppRegistryNotReady
+    from django import forms
 
     # from oscar.core.compat
     # A setting that can be used in foreign key declarations
@@ -63,7 +64,32 @@ except ImportError:
         else:
             return True
 
+    # from oscar.apps.payment.exceptions
+    class UnableToTakePayment(Exception):
+        """
+        Exception to be used for ANTICIPATED payment errors (eg card number wrong,
+        expiry date has passed).  The message passed here will be shown to the end
+        user.
+        """
+
+    # dummy for oscar.templatetags.currency_filters.currency
+    def currency(value, currency=None):
+        return value
+
+    # dummy for oscar.forms.widgets.DatePickerInput
+    DatePickerInput = forms.DateInput
+
+    # dummy for oscar.application.Application
+    class Application(object):
+        def post_process_urls(self, urlpatterns):
+            return urlpatterns
+
+
 else:  # oscar is installed, use it.
+    from oscar.apps.payment.exceptions import UnableToTakePayment
+    from oscar.core.application import Application
     from oscar.core.compat import AUTH_USER_MODEL
     from oscar.core.loading import get_model, is_model_registered
+    from oscar.forms.widgets import DatePickerInput
+    from oscar.templatetags.currency_filters import currency
 

--- a/src/oscar_accounts/compact_oscar.py
+++ b/src/oscar_accounts/compact_oscar.py
@@ -1,0 +1,69 @@
+try:
+    import oscar.core
+
+except ImportError:
+    from importlib import import_module
+    from django.apps import apps
+    from django.apps.config import MODELS_MODULE_NAME
+    from django.conf import settings
+    from django.core.exceptions import ImproperlyConfigured, AppRegistryNotReady
+
+    # from oscar.core.compat
+    # A setting that can be used in foreign key declarations
+    AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+    try:
+        AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME = AUTH_USER_MODEL.rsplit('.', 1)
+    except ValueError:
+        raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form"
+                                   " 'app_label.model_name'")
+
+    # from oscar.core.loading
+    def get_model(app_label, model_name):
+        """
+        Fetches a Django model using the app registry.
+        This doesn't require that an app with the given app label exists,
+        which makes it safe to call when the registry is being populated.
+        All other methods to access models might raise an exception about the
+        registry not being ready yet.
+        Raises LookupError if model isn't found.
+        """
+        try:
+            return apps.get_model(app_label, model_name)
+        except AppRegistryNotReady:
+            if apps.apps_ready and not apps.models_ready:
+                # If this function is called while `apps.populate()` is
+                # loading models, ensure that the module that defines the
+                # target model has been imported and try looking the model up
+                # in the app registry. This effectively emulates
+                # `from path.to.app.models import Model` where we use
+                # `Model = get_model('app', 'Model')` instead.
+                app_config = apps.get_app_config(app_label)
+                # `app_config.import_models()` cannot be used here because it
+                # would interfere with `apps.populate()`.
+                import_module('%s.%s' % (app_config.name, MODELS_MODULE_NAME))
+                # In order to account for case-insensitivity of model_name,
+                # look up the model through a private API of the app registry.
+                return apps.get_registered_model(app_label, model_name)
+            else:
+                # This must be a different case (e.g. the model really doesn't
+                # exist). We just re-raise the exception.
+                raise
+
+
+    # from oscar.core.loading
+    def is_model_registered(app_label, model_name):
+        """
+        Checks whether a given model is registered. This is used to only
+        register Oscar models if they aren't overridden by a forked app.
+        """
+        try:
+            apps.get_registered_model(app_label, model_name)
+        except LookupError:
+            return False
+        else:
+            return True
+
+else:  # oscar is installed, use it.
+    from oscar.core.compat import AUTH_USER_MODEL
+    from oscar.core.loading import get_model, is_model_registered
+

--- a/src/oscar_accounts/core.py
+++ b/src/oscar_accounts/core.py
@@ -1,4 +1,4 @@
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 from oscar_accounts import names
 

--- a/src/oscar_accounts/dashboard/app.py
+++ b/src/oscar_accounts/dashboard/app.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 from django.contrib.admin.views.decorators import staff_member_required
-from oscar.core.application import Application
 
+from oscar_accounts.compact_oscar import Application
 from oscar_accounts.dashboard import views
 
 

--- a/src/oscar_accounts/dashboard/forms.py
+++ b/src/oscar_accounts/dashboard/forms.py
@@ -4,11 +4,9 @@ from django import forms
 from django.conf import settings
 from django.core import exceptions
 from django.utils.translation import ugettext_lazy as _
-from oscar.core.loading import get_model
-from oscar.forms.widgets import DatePickerInput
-from oscar.templatetags.currency_filters import currency
 
 from oscar_accounts import codes, names
+from oscar_accounts.compact_oscar import get_model, currency, DatePickerInput
 
 Account = get_model('oscar_accounts', 'Account')
 AccountType = get_model('oscar_accounts', 'AccountType')

--- a/src/oscar_accounts/dashboard/reports.py
+++ b/src/oscar_accounts/dashboard/reports.py
@@ -1,9 +1,9 @@
 from decimal import Decimal as D
 
 from django.db.models import Sum
-from oscar.core.loading import get_model
 
 from oscar_accounts import names
+from oscar_accounts.compact_oscar import get_model
 
 AccountType = get_model('oscar_accounts', 'AccountType')
 Account = get_model('oscar_accounts', 'Account')

--- a/src/oscar_accounts/dashboard/views.py
+++ b/src/oscar_accounts/dashboard/views.py
@@ -9,10 +9,9 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
-from oscar.core.loading import get_model
-from oscar.templatetags.currency_filters import currency
 
 from oscar_accounts import exceptions, facade, names
+from oscar_accounts.compact_oscar import get_model, currency
 from oscar_accounts.dashboard import forms, reports
 
 AccountType = get_model('oscar_accounts', 'AccountType')

--- a/src/oscar_accounts/facade.py
+++ b/src/oscar_accounts/facade.py
@@ -1,6 +1,6 @@
 import logging
 
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 from oscar_accounts import core, exceptions
 

--- a/src/oscar_accounts/forms.py
+++ b/src/oscar_accounts/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 Account = get_model('oscar_accounts', 'Account')
 

--- a/src/oscar_accounts/models.py
+++ b/src/oscar_accounts/models.py
@@ -1,6 +1,5 @@
-from oscar.core.loading import is_model_registered
-
 from oscar_accounts import abstract_models
+from oscar_accounts.compact_oscar import is_model_registered
 
 if not is_model_registered('oscar_accounts', 'AccountType'):
     class AccountType(abstract_models.AccountType):

--- a/src/oscar_accounts/security.py
+++ b/src/oscar_accounts/security.py
@@ -1,4 +1,4 @@
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 IPAddressRecord = get_model('oscar_accounts', 'IPAddressRecord')
 

--- a/src/oscar_accounts/setup.py
+++ b/src/oscar_accounts/setup.py
@@ -1,4 +1,4 @@
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 
 def create_default_accounts():

--- a/src/oscar_accounts/test_factories.py
+++ b/src/oscar_accounts/test_factories.py
@@ -1,7 +1,7 @@
 from decimal import Decimal as D
 
 import factory
-from oscar.core.loading import get_model
+from oscar_accounts.compact_oscar import get_model
 
 
 class AccountFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
I gather rest of what is imported from oscar in a model (compact_oscar.py) and with a simple import check it could fallback to oscar if installed. But in case one use this interesting package alone, there will some replacements to get the oscar-accounts works alone.