### PR TITLE
Declare support for Oscar 2.1, Django 3. Clean up deprecated Python 2 code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,19 @@ sudo: false
 
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35-django111
-    - python: 3.6
-      env: TOXENV=py36-django111
-    - python: 3.7
-      env: TOXENV=py37-django111
-    - python: 3.5
-      env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
-
+    - python: 3.8
+      env: TOXENV=py38-django22
     - python: 3.6
+      env: TOXENV=py36-django30
+    - python: 3.7
+      env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
+    - python: 3.7
       env: TOXENV=lint
 
 branches:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+2.1 (TBD)
+---------
+- Added support for Oscar 2.1, Django 2.2 and Django 3.0.
+- Dropped support for Django 2.1 and lower.
+- Dropped support for Python 3.5.
+
 2.0 (2019-09-20)
 ----------------
 - Added support for Oscar 2.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,14 @@
-django-oscar>=2.0,<2.1
+django-oscar>=2.1,<2.2
 
 # Testing
 coverage==5.2
 django-webtest==1.9.7
 factory-boy>=2.10,<2.13
 pytest-django>=3.5,<3.10
-tox>=2.9,<3.15
+tox>=3.17,<3.18
 freezegun>=0.3,<0.4
 sorl-thumbnail
+
+# Linting
+isort>=5.1,<5.2
+flake8>=3.8,<3.9

--- a/sandbox/apps/checkout/views.py
+++ b/sandbox/apps/checkout/views.py
@@ -1,7 +1,7 @@
 from django import http
 from django.contrib import messages
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from oscar.apps.checkout import views
 from oscar.apps.payment import exceptions
 from oscar.apps.payment.models import Source, SourceType

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -167,8 +167,8 @@ INSTALLED_APPS = [
     'sorl.thumbnail',
 ] + oscar.INSTALLED_APPS
 
-INSTALLED_APPS[INSTALLED_APPS.index('oscar.apps.shipping')] = 'apps.shipping.apps.ShippingConfig'
-INSTALLED_APPS[INSTALLED_APPS.index('oscar.apps.checkout')] = 'apps.checkout.apps.CheckoutConfig'
+INSTALLED_APPS[INSTALLED_APPS.index('oscar.apps.shipping.apps.ShippingConfig')] = 'apps.shipping.apps.ShippingConfig'
+INSTALLED_APPS[INSTALLED_APPS.index('oscar.apps.checkout.apps.CheckoutConfig')] = 'apps.checkout.apps.CheckoutConfig'
 
 AUTHENTICATION_BACKENDS = (
     'oscar.apps.customer.auth_backends.EmailBackend',

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -11,11 +11,11 @@ from oscar_accounts.views import AccountBalanceView
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^i18n/', include('django.conf.urls.i18n')),
-    url(r'^giftcard-balance/', AccountBalanceView.as_view(), name="account-balance"),
-    url(r'^dashboard/accounts/', apps.get_app_config('accounts_dashboard').urls),
-    url(r'^', include(apps.get_app_config('oscar').urls[0])),
+    path('admin/', admin.site.urls),
+    path('i18n/', include('django.conf.urls.i18n')),
+    path('giftcard-balance/', AccountBalanceView.as_view(), name="account-balance"),
+    path('dashboard/accounts/', apps.get_app_config('accounts_dashboard').urls),
+    path('', include(apps.get_app_config('oscar').urls[0])),
 ]
 
 if settings.DEBUG:
@@ -23,6 +23,6 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL,
                           document_root=settings.MEDIA_ROOT)
     urlpatterns += [
-        url(r'^404$', TemplateView.as_view(template_name='404.html')),
-        url(r'^500$', TemplateView.as_view(template_name='500.html'))
+        path('404', TemplateView.as_view(template_name='404.html')),
+        path('500', TemplateView.as_view(template_name='500.html'))
     ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    'django>=1.11,<2.3',
+    'django>=2.2,<3.1',
     'django-oscar>=2.0',
     'python-dateutil>=2.6,<3.0',
 ]
@@ -25,12 +25,11 @@ setup(
     packages=find_packages('src'),
     include_package_data=True,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',

--- a/src/oscar_accounts/abstract_models.py
+++ b/src/oscar_accounts/abstract_models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Sum
 from django.urls import reverse
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from oscar.core.compat import AUTH_USER_MODEL
 from treebeard.mp_tree import MP_Node
@@ -382,7 +382,7 @@ class Transfer(models.Model):
 
     def _generate_reference(self):
         obj = hmac.new(key=settings.SECRET_KEY.encode(),
-                       msg=six.text_type(self.id).encode(),
+                       msg=str(self.id).encode(),
                        digestmod=hashlib.md5)
         return obj.hexdigest().upper()
 

--- a/src/oscar_accounts/checkout/forms.py
+++ b/src/oscar_accounts/checkout/forms.py
@@ -1,7 +1,7 @@
 from decimal import Decimal as D
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from oscar.core.loading import get_model
 from oscar.templatetags.currency_filters import currency
 

--- a/src/oscar_accounts/checkout/gateway.py
+++ b/src/oscar_accounts/checkout/gateway.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from oscar.apps.payment.exceptions import UnableToTakePayment
 from oscar.core.loading import get_model
 

--- a/src/oscar_accounts/dashboard/forms.py
+++ b/src/oscar_accounts/dashboard/forms.py
@@ -3,7 +3,7 @@ from decimal import Decimal as D
 from django import forms
 from django.conf import settings
 from django.core import exceptions
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from oscar.core.loading import get_model
 from oscar.forms.widgets import DatePickerInput
 from oscar.templatetags.currency_filters import currency

--- a/src/oscar_accounts/dashboard/views.py
+++ b/src/oscar_accounts/dashboard/views.py
@@ -8,7 +8,7 @@ from django.db.models import Sum
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from oscar.core.loading import get_model
 from oscar.templatetags.currency_filters import currency

--- a/src/oscar_accounts/forms.py
+++ b/src/oscar_accounts/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from oscar.core.loading import get_model
 
 Account = get_model('oscar_accounts', 'Account')

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,23 @@
 [tox]
-envlist = py{35,36,37}-django{111,22}
+envlist = py{36,37,38}-django{22,30}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 deps =
     -r{toxinidir}/requirements.txt
-    django111: django>=1.11,<1.12
     django22: django>=2.2,<2.3
+    django30: django>=3.0,<3.1
 
 [testenv:lint]
-basepython = python3.6
+basepython = python3.7
 deps =
-    flake8
-    isort
+    -r{toxinidir}/requirements.txt
 commands =
     flake8 src tests setup.py
-    isort -q -c --recursive --diff src tests setup.py
+    isort -q -c --diff src tests setup.py
 
 [testenv:coverage-report]
-basepython = python3.6
+basepython = python3.7
 deps = coverage
 skip_install = true
 commands =


### PR DESCRIPTION
Closes #98. Closes #99.