### PR TITLE
fix: improve performance on saving models

### DIFF
--- a/src/oscar_accounts/abstract_models.py
+++ b/src/oscar_accounts/abstract_models.py
@@ -237,14 +237,8 @@ class Account(models.Model):
         return (self.end_date - from_date).days
 
     def close(self):
-        """This object must be in the database before calling this function.
-
-        Only account with zero balance can be closed
-
-        Saves these changes to the database but doesn't save any other changes you may have made to the object.
-
-        Changed in version 2.2
-        """
+        # Only account with zero balance can be closed
+        # Saves these changes to the database but doesn't save any other changes you may have made to the object.
         if self.balance > 0:
             raise exceptions.AccountNotEmpty()
         self.status = self.__class__.CLOSED

--- a/src/oscar_accounts/abstract_models.py
+++ b/src/oscar_accounts/abstract_models.py
@@ -476,38 +476,16 @@ class IPAddressRecord(models.Model):
         return self.ip_address
 
     def increment_failures(self):
-        """This object must be in the database before calling this function.
-
-        Increments total_failures and consecutive_failures by one.
-        Updates the time of the latest failure.
-        Saves these changes to the database but doesn't save any other changes you may have made to the object.
-
-        Changed in version 2.2
-        """
         self.total_failures += 1
         self.consecutive_failures += 1
         self.date_last_failure = timezone.now()
         self.save(update_fields=['total_failures', 'consecutive_failures', 'date_last_failure'])
 
     def increment_blocks(self):
-        """This object must be in the database before calling this function.
-
-        Increments total_blocks by one.
-        Saves these changes to the database but doesn't save any other changes you may have made to the object.
-
-        Changed in version 2.2
-        """
         self.total_blocks += 1
         self.save(update_fields=['total_blocks'])
 
     def reset(self):
-        """This object must be in the database before calling this function.
-
-        Resets consecutive_failures to zero.
-        Saves these changes to the database but doesn't save any other changes you may have made to the object.
-
-        Changed in version 2.2
-        """
         self.consecutive_failures = 0
         self.save(update_fields=['consecutive_failures'])
 

--- a/src/oscar_accounts/abstract_models.py
+++ b/src/oscar_accounts/abstract_models.py
@@ -237,7 +237,14 @@ class Account(models.Model):
         return (self.end_date - from_date).days
 
     def close(self):
-        # Only account with zero balance can be closed
+        """This object must be in the database before calling this function.
+
+        Only account with zero balance can be closed
+
+        Saves these changes to the database but doesn't save any other changes you may have made to the object.
+
+        Changed in version 2.2
+        """
         if self.balance > 0:
             raise exceptions.AccountNotEmpty()
         self.status = self.__class__.CLOSED
@@ -475,16 +482,38 @@ class IPAddressRecord(models.Model):
         return self.ip_address
 
     def increment_failures(self):
+        """This object must be in the database before calling this function.
+
+        Increments total_failures and consecutive_failures by one.
+        Updates the time of the latest failure.
+        Saves these changes to the database but doesn't save any other changes you may have made to the object.
+
+        Changed in version 2.2
+        """
         self.total_failures += 1
         self.consecutive_failures += 1
         self.date_last_failure = timezone.now()
         self.save(update_fields=['total_failures', 'consecutive_failures', 'date_last_failure'])
 
     def increment_blocks(self):
+        """This object must be in the database before calling this function.
+
+        Increments total_blocks by one.
+        Saves these changes to the database but doesn't save any other changes you may have made to the object.
+
+        Changed in version 2.2
+        """
         self.total_blocks += 1
         self.save(update_fields=['total_blocks'])
 
     def reset(self):
+        """This object must be in the database before calling this function.
+
+        Resets consecutive_failures to zero.
+        Saves these changes to the database but doesn't save any other changes you may have made to the object.
+
+        Changed in version 2.2
+        """
         self.consecutive_failures = 0
         self.save(update_fields=['consecutive_failures'])
 

--- a/src/oscar_accounts/abstract_models.py
+++ b/src/oscar_accounts/abstract_models.py
@@ -147,7 +147,7 @@ class Account(models.Model):
             self.code = self.code.upper()
         # Ensure the balance is always correct when saving
         self.balance = self._balance()
-        return super(Account, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     def _balance(self):
         aggregates = self.transactions.aggregate(sum=Sum('amount'))
@@ -241,7 +241,7 @@ class Account(models.Model):
         if self.balance > 0:
             raise exceptions.AccountNotEmpty()
         self.status = self.__class__.CLOSED
-        self.save()
+        self.save(update_fields=['status'])
 
     def as_dict(self):
         data = {
@@ -378,7 +378,7 @@ class Transfer(models.Model):
         super().save(*args, **kwargs)
         if not self.reference:
             self.reference = self._generate_reference()
-            super().save()
+            super().save(update_fields=['reference'])
 
     def _generate_reference(self):
         obj = hmac.new(key=settings.SECRET_KEY.encode(),
@@ -478,15 +478,15 @@ class IPAddressRecord(models.Model):
         self.total_failures += 1
         self.consecutive_failures += 1
         self.date_last_failure = timezone.now()
-        self.save()
+        self.save(update_fields=['total_failures', 'consecutive_failures', 'date_last_failure'])
 
     def increment_blocks(self):
         self.total_blocks += 1
-        self.save()
+        self.save(update_fields=['total_blocks'])
 
     def reset(self):
         self.consecutive_failures = 0
-        self.save()
+        self.save(update_fields=['consecutive_failures'])
 
     def is_blocked(self):
         return (self.is_temporarily_blocked() or self.is_permanently_blocked())

--- a/tests/unit/model_tests.py
+++ b/tests/unit/model_tests.py
@@ -14,6 +14,7 @@ class TestAnAccount(TestCase):
 
     def setUp(self):
         self.account = Account()
+        self.account.save()
 
     def test_is_open_by_default(self):
         self.assertEqual(Account.OPEN, self.account.status)


### PR DESCRIPTION
Use [update_fields](https://docs.djangoproject.com/en/2.2/ref/models/instances/#specifying-which-fields-to-save) on save when used in a limited context. Also prevents other potentially unwanted data from being saved.