### PR TITLE
Avoid django dependency (version) conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    'django>=2.2,<3.2',
     'django-oscar>=3.0',
     'python-dateutil>=2.6,<3.0',
 ]


### PR DESCRIPTION
Implicitly use django-oscar's (django) version to resolve dependency conflict.